### PR TITLE
Improve colorize prompt

### DIFF
--- a/dot_bashrc
+++ b/dot_bashrc
@@ -24,8 +24,8 @@ export HISTFILESIZE=10000
 # ------------------------------------------------------------------------------
 # Prompt (bash-specific)
 # ------------------------------------------------------------------------------
-# _PC and _PR set in .shellrc; \[...\] marks non-printing sequences for bash
-PS1="\[${_PC}\]\u@\h:\w\$\[${_PR}\] "
+# _PROMPT_ID, _PROMPT_INFO, and _PROMPT_RESET set in .shellrc; \[...\] marks non-printing sequences for bash
+PS1="\[${_PROMPT_ID}\]\u@\h\[${_PROMPT_INFO}\]:\w\$\[${_PROMPT_RESET}\] "
 
 # ------------------------------------------------------------------------------
 # nvm bash completion (bash-specific) (OPTIONAL)

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline.sh"
+  },
+  "permissions": {
+    "ask": [
+      "Bash(ssh *)"
+    ]
+  }
+}

--- a/dot_claude/statusline.sh
+++ b/dot_claude/statusline.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+data=$(cat)
+session_id=$(echo "$data" | jq -r '.session_id // "default"')
+total=$(echo "$data" | jq '(.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)')
+prev_file="/tmp/.claude-statusline-prev-${session_id}"
+cum_file="/tmp/.claude-statusline-cum-${session_id}"
+prev=$(cat "$prev_file" 2>/dev/null || echo 0)
+cum=$(cat "$cum_file" 2>/dev/null || echo 0)
+
+# If total went down, it's a new context (after /clear) — use current total as delta
+if [ "$total" -ge "$prev" ]; then
+  delta=$((total - prev))
+else
+  delta=$total
+fi
+
+cum=$((cum + delta))
+printf "%d" "$total" > "$prev_file"
+printf "%d" "$cum" > "$cum_file"
+
+echo "$data" | jq -r --argjson delta "$delta" --argjson cum "$cum" '
+def commas(n): n | tostring as $s | ($s | length) as $len | if $len <= 3 then $s elif $len <= 6 then $s[0:$len-3] + "," + $s[$len-3:] elif $len <= 9 then $s[0:$len-6] + "," + $s[$len-6:$len-3] + "," + $s[$len-3:] else $s end;
+def rpt(s; n): [range(n) | s] | join("");
+def bar(pct; width): (pct / 100 * width | round) as $filled | (width - $filled) as $empty | rpt("▓"; $filled) + rpt("░"; $empty);
+def fmt(n): if n >= 1000 then (((n/1000*10)|round)/10|tostring)+"k" else (n|tostring) end;
+(.context_window.remaining_percentage // 100) as $rem |
+(100 - $rem) as $used_pct |
+"" + (.model.display_name // "?") + " " + bar($used_pct; 6) + " " + ($used_pct | floor | tostring) + "% | " + "+" + commas($delta) + " tokens | " + fmt($cum) + " session"
+'

--- a/dot_shellrc
+++ b/dot_shellrc
@@ -4,15 +4,18 @@
 # ------------------------------------------------------------------------------
 # Prompt color
 # ------------------------------------------------------------------------------
-# Red for root, green for SSH sessions, blue for local workstations
+# _PROMPT_ID    = user@host color: red for root, yellow for remote (SSH), green for local
+# _PROMPT_INFO  = path/context info color: always blue
+# _PROMPT_RESET = reset color
 if [ "$(id -u)" = "0" ]; then
-  _PC=$(printf '\033[31m')   # red (root)
+  _PROMPT_ID=$(printf '\033[31m')    # red (root)
 elif [ -n "$SSH_CLIENT" ] || [ -n "$SSH_TTY" ] || [ -n "$SSH_CONNECTION" ]; then
-  _PC=$(printf '\033[32m')   # green (SSH)
+  _PROMPT_ID=$(printf '\033[33m')    # yellow (remote)
 else
-  _PC=$(printf '\033[34m')   # blue (local)
+  _PROMPT_ID=$(printf '\033[32m')    # green (local)
 fi
-_PR=$(printf '\033[0m')      # reset
+_PROMPT_INFO=$(printf '\033[34m')    # blue
+_PROMPT_RESET=$(printf '\033[0m')    # reset
 
 # ------------------------------------------------------------------------------
 # Editor

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -6,6 +6,6 @@ source "$HOME/.shellrc"
 # ------------------------------------------------------------------------------
 # Prompt (zsh-specific)
 # ------------------------------------------------------------------------------
-# _PC and _PR set in .shellrc; %{...%} marks non-printing sequences for zsh
+# _PROMPT_ID, _PROMPT_INFO, and _PROMPT_RESET set in .shellrc; %{...%} marks non-printing sequences for zsh
 setopt PROMPT_SUBST
-PROMPT="%{${_PC}%}%n@%m:%~%# %{${_PR}%} "
+PROMPT="%{${_PROMPT_ID}%}%n@%m%{${_PROMPT_INFO}%}:%~%# %{${_PROMPT_RESET}%} "


### PR DESCRIPTION
- Includes basic claude settings
- Only `user@host` color changes colors and remote is now yellow instead of green (no longer clashing with debian defaults)