### PR TITLE
Add kitty tab-bar working/waiting indicator driven by Claude hooks

### DIFF
--- a/dot_claude/executable_tab-state.sh
+++ b/dot_claude/executable_tab-state.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# IMPORTANT: Managed by chezmoi - do not edit this copy directly.
+# Source: ~/.local/share/chezmoi - edit there, then run `chezmoi apply`.
+# If you edit this file directly, notify the user and reconcile with the chezmoi source.
+#
+# Record this Claude session's state for the kitty tab bar to render
+# (read by ~/.config/kitty/tab_bar.py). We write a small per-window file
+# instead of emitting a terminal escape, because Claude Code runs hooks
+# without a controlling tty (writing to /dev/tty fails), and this needs no
+# kitty remote control. Always exits 0 so a hook can never surface an error.
+#
+# Usage: tab-state.sh working|waiting|idle
+
+[ -n "$KITTY_WINDOW_ID" ] || exit 0
+
+dir=/tmp/claude-kitty-state
+file="$dir/$KITTY_WINDOW_ID"
+mkdir -p "$dir" 2>/dev/null
+
+case "$1" in
+    idle) rm -f "$file" 2>/dev/null ;;
+    working | waiting) printf '%s' "$1" >"$file" 2>/dev/null ;;
+esac
+
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -36,6 +36,23 @@
       "Bash(wget *)"
     ]
   },
+  "hooks": {
+    "UserPromptSubmit": [
+      { "hooks": [{ "type": "command", "command": "\"$HOME/.claude/tab-state.sh\" working" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "\"$HOME/.claude/tab-state.sh\" waiting" }] }
+    ],
+    "Notification": [
+      { "hooks": [{ "type": "command", "command": "\"$HOME/.claude/tab-state.sh\" waiting" }] }
+    ],
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "\"$HOME/.claude/tab-state.sh\" idle" }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "\"$HOME/.claude/tab-state.sh\" idle" }] }
+    ]
+  },
   "model": "opus[1m]",
   "statusLine": {
     "type": "command",

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -1459,7 +1459,7 @@ mouse_map shift+middle release ungrabbed,grabbed no-op
 #: of the neighboring tab.
 
 tab_title_template         " {index}: {title} "
-tab_bar_style              powerline
+tab_bar_style              custom
 tab_powerline_style        slanted
 tab_bar_margin_height      4.0 0.0
 tab_bar_background         #2b2b2b

--- a/dot_config/kitty/tab_bar.py
+++ b/dot_config/kitty/tab_bar.py
@@ -1,0 +1,84 @@
+# IMPORTANT: Managed by chezmoi - do not edit this copy directly.
+# Source: ~/.local/share/chezmoi - edit there, then run `chezmoi apply`.
+# If you edit this file directly, notify the user and reconcile with the chezmoi source.
+#
+# Custom kitty tab bar: prepends a coloured state glyph, then hands the tab off
+# to kitty's built-in powerline renderer (so tab_bar_style powerline +
+# tab_powerline_style and the tab_title_template are all preserved, and the
+# window title itself is left untouched).
+#
+# State is written per-window by Claude Code hooks (see ~/.claude/tab-state.sh,
+# wired up in ~/.claude/settings.json) into /tmp/claude-kitty-state/<window-id>:
+#
+#   UserPromptSubmit -> "working"  -> ▸ green
+#   Stop/Notification -> "waiting" -> ⏸ amber (takes precedence: it needs you)
+#   SessionStart/End -> file removed -> idle -> no glyph
+#
+# Tweak the glyphs/colours/precedence in STATES below.
+
+import os
+
+from kitty.tab_bar import as_rgb, draw_tab_with_powerline, get_boss
+
+STATE_DIR = "/tmp/claude-kitty-state"
+
+# checked in order -> first match wins (waiting outranks working)
+# (state name, glyph, 0xRRGGBB)
+STATES = (
+    ("waiting", "⏸", 0xFFB000),  # amber
+    ("working", "▸", 0x00CC66),  # green
+)
+
+
+def _states_for_tab(tab_id):
+    boss = get_boss()
+    if boss is None:
+        return set()
+    try:
+        tab = boss.tab_for_id(tab_id)
+    except Exception:
+        return set()
+    if tab is None:
+        return set()
+    # collect this tab's window ids (defensive across kitty versions)
+    wids = []
+    try:
+        wids = [w.id for w in tab]
+    except TypeError:
+        active = getattr(tab, "active_window", None)
+        if active is not None:
+            wids.append(active.id)
+        wids += list(getattr(tab, "all_window_ids_except_active_window", []) or [])
+    except Exception:
+        return set()
+    found = set()
+    for wid in wids:
+        try:
+            with open(os.path.join(STATE_DIR, str(wid))) as fh:
+                found.add(fh.read().strip())
+        except OSError:
+            pass
+    return found
+
+
+def draw_tab(
+    draw_data, screen, tab, before, max_tab_length, index, is_last, extra_data
+):
+    try:
+        states = _states_for_tab(tab.tab_id)
+        for name, glyph, color in STATES:
+            if name in states:
+                orig_fg = screen.cursor.fg
+                screen.draw(" ")
+                screen.cursor.fg = as_rgb(color)
+                screen.draw(glyph)
+                screen.cursor.fg = orig_fg
+                # no trailing space: the tab_title_template's own leading
+                # space (" {index}: ...") keeps the glyph off the title
+                break
+    except Exception:
+        # never let a rendering error break the whole tab bar
+        pass
+    return draw_tab_with_powerline(
+        draw_data, screen, tab, before, max_tab_length, index, is_last, extra_data
+    )


### PR DESCRIPTION
Shows per-tab Claude session state in the kitty tab bar so you can spot which tabs are waiting on you.

## What
- **Green `▸` = working**, **amber `⏸` = waiting** (waiting outranks working), no glyph = idle.
- Per kitty window, so every tab is independent and it survives tab renames.
- Preserves the existing slanted-powerline look and Claude's task-summary titles.

## How
- `dot_config/kitty/tab_bar.py` — custom `draw_tab` reads per-window state files, draws the padded coloured glyph, delegates to `draw_tab_with_powerline`.
- `dot_config/kitty/kitty.conf` — `tab_bar_style custom` (only change).
- `dot_claude/executable_tab-state.sh` — hook script; writes `/tmp/claude-kitty-state/<window-id>`. Uses a file (not `/dev/tty` or remote control) because Claude hooks have no controlling terminal, and always exits 0 so it can't surface an error.
- `dot_claude/settings.json` — UserPromptSubmit/Stop/Notification/SessionStart/SessionEnd hooks wire into the script.

Tweak glyphs/colours in `STATES` at the top of `tab_bar.py`.