### PR TITLE
Disable remote control by default at startup

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -124,6 +124,7 @@
   },
   "tui": "fullscreen",
   "agentPushNotifEnabled": true,
+  "remoteControlAtStartup": false,
   "voiceEnabled": true,
   "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
Adds `remoteControlAtStartup: false` to `dot_claude/settings.json` so interactive Claude Code sessions start with remote control off by default.

This is the canonical key the app itself writes (an earlier attempt used the non-existent `remoteControlDefault`); the value here was captured from the live settings via `chezmoi re-add`, so source and `$HOME` stay in sync with no drift.

https://claude.ai/code/session_01AAcQAHUamrjwKjwkKrPnva