### PR TITLE
Document kitty tab-icon system + add diagnostic logging for wrong-icon bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,3 +72,4 @@ ansible-playbook ~/.bootstrap/provision-workstation-linux.yml --ask-become-pass 
 - `.chezmoiignore` excludes `CLAUDE.md`, `README.md`, `docs/`, and `.gitignore` from being deployed to the home directory
 - Editing managed files: follow [`docs/managed-dotfiles-policy.md`](docs/managed-dotfiles-policy.md) — edit the chezmoi source, never the live `$HOME` copy
 - Changing Claude Code permission rules (allow/ask/deny for Bash commands, mode-conditional gating): follow [`docs/claude-permission-gating.md`](docs/claude-permission-gating.md) — the native `settings.json` rules and the `permission-gate.sh` hook must be kept in sync
+- Kitty tab status icons for Claude Code (▸ working / ⏸ waiting), plus the known "wrong icon" bug and its live diagnostic instrumentation: see [`docs/kitty-claude-tab-icons.md`](docs/kitty-claude-tab-icons.md)

--- a/docs/kitty-claude-tab-icons.md
+++ b/docs/kitty-claude-tab-icons.md
@@ -1,0 +1,114 @@
+# Kitty tab status icons for Claude Code
+
+Each kitty tab shows a small coloured glyph reflecting the Claude Code session
+running in it:
+
+| Glyph | Colour | Meaning | Written by |
+|---|---|---|---|
+| `▸` | green (`0x00CC66`) | working | `UserPromptSubmit`, `PreToolUse`, `PostToolUse` |
+| `⏸` | amber (`0xFFB000`) | waiting / needs you | `Stop`, `Notification` |
+| *(none)* | — | idle | `SessionStart`, `SessionEnd` (file removed) |
+
+This doc is the pickup point for the **known "wrong icon" bug** (see below) and
+the diagnostic instrumentation currently wired up to chase it. For the mechanics,
+read the live files — they carry their own header comments:
+
+- `dot_config/kitty/tab_bar.py` → `~/.config/kitty/tab_bar.py` (renderer)
+- `dot_claude/executable_tab-state.sh` → `~/.claude/tab-state.sh` (state writer)
+- `dot_claude/settings.json` → `~/.claude/settings.json` (hook → event wiring)
+
+## How it works
+
+State is a **single last-writer-wins file per kitty window** at
+`/tmp/claude-kitty-state/<KITTY_WINDOW_ID>`, containing the literal word
+`working` or `waiting` (absent = idle). Claude Code hooks run `tab-state.sh
+<state>`; the script writes the file. `tab_bar.py` is imported by kitty once at
+startup and, on every tab-bar redraw, reads the state file(s) for the windows in
+each tab and prepends the glyph before handing off to kitty's powerline renderer.
+
+Design notes worth knowing:
+
+- **Why a file, not an escape sequence:** Claude Code runs hooks without a
+  controlling tty, so writing to `/dev/tty` fails. A file needs no kitty remote
+  control (which is disabled by default — see commit `9fb38ac`).
+- **Precedence:** `waiting` outranks `working` when a tab has multiple windows
+  (a split that needs you wins). See `STATES` in `tab_bar.py`.
+- **Stale-session sweep:** kitty reuses window ids (1, 2, 3…) across restarts,
+  but state files survive until reboot, so `tab_bar.py` records its import time
+  (`_SESSION_START`) and `_sweep_stale()` drops any state file older than that on
+  the first tab of each redraw. This is *cross-session* hygiene only — it does
+  not fix the in-session bug below.
+
+## Known bug: intermittent wrong icon
+
+Reported 2026-07-17. Icons are *usually* right but occasionally stick. Because
+the state file is last-writer-wins with **no ordering or ground-truth check**, a
+missed or out-of-order write persists until the next event happens to correct it
+(it self-heals on the next turn). There are **two opposite failure modes**:
+
+1. **Stuck `working`** (▸ play shown while the session is actually stopped). The
+   corrective `waiting` write never landed. Prime suspect: **interrupts** — ESC
+   aborts a turn and the `Stop` hook does not reliably fire, so nothing writes
+   `waiting`.
+2. **Stuck `waiting`** (⏸ pause shown while the session is actually running).
+   Observed during **repeated subagent shell-outs** (Task tool), *not* an
+   interrupt. A `waiting` was written and the expected `working` refresh didn't
+   overwrite it.
+
+Open questions the docs don't answer (hence the instrumentation):
+
+- Does `Stop` fire on ESC interrupt? (Empirically: seems **not**.)
+- Do a subagent's `PreToolUse`/`PostToolUse` fire the **parent window's** hooks?
+- Does the statusline command tick while the session is **idle**, or only while
+  working? (Early data: fires irregularly on activity, 0.5–12s gaps *while
+  working* — so any freshness-based reconciler needs a generous threshold.)
+
+## Diagnostic instrumentation (temporary)
+
+Opt-in logging, gated by a flag file so it costs nothing when off:
+
+```sh
+# Enable
+mkdir -p /tmp/claude-kitty-state && touch /tmp/claude-kitty-state/.debug
+# Disable (no chezmoi apply needed)
+rm /tmp/claude-kitty-state/.debug
+```
+
+When the flag exists:
+
+- `tab-state.sh` appends to `/tmp/claude-kitty-state/debug.log` — hi-res
+  timestamp, pid, window id, the state written, and the real `hook_event_name` /
+  `tool_name` / `agent_type`+`agent_id` parsed from the hook JSON on stdin.
+- `statusline.sh` appends to `/tmp/claude-kitty-state/statusline.log` — hi-res
+  timestamp + window id, i.e. statusline invocation cadence.
+
+Both logging blocks are clearly fenced in their scripts and are **meant to be
+removed** once the bug is fixed. If you're reading this after the fix shipped and
+those blocks are still there, delete them (and this section).
+
+### Analysing a report
+
+When an icon is wrong, note the window and what it showed vs reality, then
+reconstruct the merged per-window timeline (state writes interleaved with
+statusline beats) and compare against the current on-disk state. Ad-hoc:
+
+```sh
+# merged timeline for one window, oldest first
+{ sed 's/$/ KIND=state/' /tmp/claude-kitty-state/debug.log
+  sed 's/$/ event=beat KIND=beat/' /tmp/claude-kitty-state/statusline.log; } \
+  | sort -n | grep 'wid=<ID>'
+# what the renderer currently sees
+cat /tmp/claude-kitty-state/<ID>
+```
+
+What to look for: a final `wrote=working` with the statusline going silent right
+after (→ stuck-working / interrupt), or a `wrote=waiting` from `Notification`
+landing mid-work with no following `working` (→ stuck-waiting).
+
+## Fix direction (not yet implemented)
+
+Likely a combination of: (a) an interrupt-safe way to mark `waiting` when a turn
+ends for any reason, and (b) a freshness/ground-truth reconciler in `tab_bar.py`
+so a stale `working` downgrades instead of sticking. Nail the open questions from
+the logs *first* — the two failure modes have different causes and a speculative
+single fix risks trading one wrong-direction error for another.

--- a/dot_claude/executable_tab-state.sh
+++ b/dot_claude/executable_tab-state.sh
@@ -10,6 +10,13 @@
 # kitty remote control. Always exits 0 so a hook can never surface an error.
 #
 # Usage: tab-state.sh working|waiting|idle
+#
+# DIAGNOSTIC LOGGING (temporary): if the flag file $dir/.debug exists, every
+# invocation appends a line to $dir/debug.log capturing the hi-res time, pid,
+# window id, the state we were told to write, and the real hook event name /
+# tool / subagent id parsed from the hook JSON on stdin. This lets us build an
+# exact per-window timeline to diagnose intermittent wrong icons. Turn it off
+# by removing the flag file (no chezmoi apply needed): rm /tmp/claude-kitty-state/.debug
 
 [ -n "$KITTY_WINDOW_ID" ] || exit 0
 
@@ -17,9 +24,35 @@ dir=/tmp/claude-kitty-state
 file="$dir/$KITTY_WINDOW_ID"
 mkdir -p "$dir" 2>/dev/null
 
-case "$1" in
+state=$1
+
+# --- diagnostic logging (opt-in via flag file) ---------------------------
+if [ -f "$dir/.debug" ]; then
+    # Capture the hook JSON from stdin (hooks always pipe JSON + EOF; guard
+    # against blocking if run by hand from a terminal).
+    payload=""
+    if [ ! -t 0 ]; then
+        payload=$(cat 2>/dev/null)
+    fi
+    field() {
+        printf '%s' "$payload" | sed -n \
+            "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n1
+    }
+    event=$(field hook_event_name)
+    tool=$(field tool_name)
+    aid=$(field agent_id)
+    atype=$(field agent_type)
+    ts=$(perl -MTime::HiRes -e 'printf "%.3f", Time::HiRes::time()' 2>/dev/null) \
+        || ts=$(date +%s)
+    printf '%s pid=%s wid=%s wrote=%s event=%s tool=%s agent=%s/%s\n' \
+        "$ts" "$$" "$KITTY_WINDOW_ID" "${state:-?}" "${event:-?}" \
+        "${tool:-}" "${atype:-}" "${aid:-}" >> "$dir/debug.log" 2>/dev/null
+fi
+# -------------------------------------------------------------------------
+
+case "$state" in
     idle) rm -f "$file" 2>/dev/null ;;
-    working | waiting) printf '%s' "$1" >"$file" 2>/dev/null ;;
+    working | waiting) printf '%s' "$state" >"$file" 2>/dev/null ;;
 esac
 
 exit 0

--- a/dot_claude/statusline.sh
+++ b/dot_claude/statusline.sh
@@ -5,6 +5,16 @@
 
 data=$(cat)
 session_id=$(echo "$data" | jq -r '.session_id // "default"')
+
+# DIAGNOSTIC (temporary): log statusline invocation cadence per kitty window so
+# we can tell whether Claude Code invokes the statusline while idle vs only
+# while working (decides if tab-bar freshness reconciliation is viable).
+# Disable by removing the flag: rm /tmp/claude-kitty-state/.debug
+if [ -f /tmp/claude-kitty-state/.debug ]; then
+  _ts=$(perl -MTime::HiRes -e 'printf "%.3f", Time::HiRes::time()' 2>/dev/null || date +%s)
+  printf '%s wid=%s session=%s\n' "$_ts" "${KITTY_WINDOW_ID:-?}" "$session_id" \
+    >> /tmp/claude-kitty-state/statusline.log 2>/dev/null
+fi
 total=$(echo "$data" | jq '(.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)')
 prev_file="/tmp/.claude-statusline-prev-${session_id}"
 cum_file="/tmp/.claude-statusline-cum-${session_id}"


### PR DESCRIPTION
## Why

The kitty tab status icons (▸ working / ⏸ waiting) occasionally stick on the wrong state — not often, but noticeably. The per-window state file (`/tmp/claude-kitty-state/<window-id>`) is **last-writer-wins with no ordering or ground-truth check**, so a missed or out-of-order hook write persists until the next event happens to correct it (it self-heals on the next turn).

Two opposite failure modes were observed, so it's not one bug:
- **Stuck `working`** (play while stopped) — likely **interrupts**: ESC aborts a turn without a reliable `Stop` hook, so nothing writes `waiting`.
- **Stuck `waiting`** (pause while running) — seen during **repeated subagent shell-outs**; a `waiting` was written and the expected `working` refresh didn't overwrite it.

Rather than guess at undocumented Claude Code behavior, this PR adds evidence-gathering instrumentation first.

## What

- **`tab-state.sh`** — when `/tmp/claude-kitty-state/.debug` exists, log each write with hi-res time, pid, window id, state written, and the real `hook_event_name` / tool / subagent id parsed from the hook JSON on stdin.
- **`statusline.sh`** — log invocation cadence per window (to settle whether the statusline ticks while idle — decides if a freshness-based reconciler is viable).
- Both logging blocks are **flag-gated** (zero cost when the flag is absent) and are meant to be **removed once the bug is fixed**.
- **`docs/kitty-claude-tab-icons.md`** (new) — documents the subsystem: architecture, the known bug + both failure modes, how to enable/analyse the instrumentation, and the fix direction. Linked from `CLAUDE.md`.

## Note

No behavior change to the icons themselves — the logging is inert unless the debug flag file is created. `docs/` and `CLAUDE.md` are chezmoi-ignored (repo-only).