### PR TITLE
Fix wrong kitty tab icons: repaint tab bar when state files change

### DIFF
--- a/docs/kitty-claude-tab-icons.md
+++ b/docs/kitty-claude-tab-icons.md
@@ -76,18 +76,31 @@ Things that cost real debugging time — read these before re-deriving them:
 
 ## Known bug: intermittent wrong icon
 
-Reported 2026-07-17. Icons are *usually* right but occasionally stick. Because
-the state file is last-writer-wins with **no ordering or ground-truth check**, a
-missed or out-of-order write persists until the next event happens to correct it
-(it self-heals on the next turn). There are **two opposite failure modes**:
+Reported 2026-07-17. Icons are *usually* right but occasionally stick.
+
+> **Dominant cause found 2026-07-21: renderer lag, not the writer.** Most
+> "wrong icon that heals when you touch it" reports are the *renderer* — the
+> state **file** is correct but the glyph hadn't repainted. Fixed with a redraw
+> timer; see "Root cause: renderer never repainted" below. Read that first. The
+> writer-side failure modes below are real but secondary.
+
+Because the state file is last-writer-wins with **no ordering or ground-truth
+check**, a missed or out-of-order write can also persist until the next event
+corrects it (it self-heals on the next turn). The **two writer-side failure
+modes**:
 
 1. **Stuck `working`** (▸ play shown while the session is actually stopped). The
-   corrective `waiting` write never landed. Prime suspect: **interrupts** — ESC
-   aborts a turn and the `Stop` hook does not reliably fire, so nothing writes
-   `waiting`.
+   corrective `waiting` write never landed. Suspect: **interrupts** — ESC aborts
+   a turn and the `Stop` hook does not reliably fire. NOTE (2026-07-21): most
+   reports of this were actually renderer lag — the `waiting` file *was* written
+   on a normal `Stop`, the glyph just never repainted. True ESC-with-no-`Stop` is
+   a smaller residual.
 2. **Stuck `waiting`** (⏸ pause shown while the session is actually running).
-   **Root cause found (2026-07-17) and fixed** — see below. Was mis-attributed to
-   subagents; the real trigger is `Notification`'s idle nudge firing mid-tool.
+   Two distinct triggers:
+   - `Notification`'s idle nudge firing mid-tool — **found & fixed 2026-07-17**,
+     see "Root cause of stuck `waiting`" below.
+   - **Permission-gated tool running after you approve** — **known, accepted
+     limitation (2026-07-21)**, see "Permission-gated tool shows ⏸" below.
 
 Open questions the docs don't answer (hence the instrumentation):
 
@@ -124,6 +137,58 @@ are monotonic and never recycled (ids observed: 2, 4, 36, 39 — strictly
 increasing), and each window's hooks/renderer agree on its id. Closing a tab can
 orphan a state file, but no live window ever reads it. Cross-*restart* reuse is
 handled by `_sweep_stale()`.
+
+### Root cause: renderer never repainted (found & fixed 2026-07-21)
+
+The dominant "wrong icon" was **not** a bad state file — it was the file being
+right while the **glyph** was stale. kitty repaints the tab bar only on its own
+triggers (focus change, keypress, focused-window output, bell, title change). A
+state file changing on disk is **not** one of them. So when a session transitions
+`working`↔`waiting` on a tab you're not interacting with — a background tab, or
+the tab that just finished its turn and went quiet — the glyph keeps showing the
+previous state until some *unrelated* event repaints the bar. That is exactly the
+"heals when you touch it" symptom, and it's **worse with more tabs** (background
+tabs essentially never self-repaint). It also explains why a *normal* `Stop`
+(non-ESC) leaves a stale ▸: the `waiting` file is written instantly, but nothing
+tells kitty to repaint until you move the mouse / press a key.
+
+Confirmed 2026-07-21 by comparing the debug log (file write times, always
+sub-second) against what was on screen: the file was correct; the glyph lagged.
+
+**Fix:** `tab_bar.py` registers an `add_timer` callback (`_poll_redraw`, 2s) that
+fingerprints the state dir (numeric files only — logging churn is skipped) and
+calls `mark_tab_bar_dirty()` **only when a state file's mtime actually changed**.
+So a glyph now tracks its file within ~2s even on an untouched tab. Cost is
+negligible: when nothing changed (idle sessions, or no Claude open — the timer
+lives in kitty, not Claude) a tick is just one `listdir` + a few `stat`s and
+forces **no** repaint; kitty also skips the repaint for occluded windows. This is
+a *renderer* change only — state stays 100% hook-driven, so the earlier "no
+heartbeat, so no TTL reconciler" conclusion is untouched (that was about
+inventing *writer* state; this only re-reads files the renderer already reads).
+
+> **Activation requires a full kitty restart.** kitty imports `tab_bar.py` once
+> at startup; `load_config_file` does **not** re-import it (see `kitty.conf` note:
+> "when changing … the tab bar, a full restart is needed"). The fix is live in
+> the source/`$HOME` copy but a running kitty won't use it until relaunched.
+
+### Permission-gated tool shows ⏸ (accepted limitation, 2026-07-21)
+
+When a tool needs a permission prompt, the hook order is `PreToolUse` (→working)
+→ `Notification` "needs your permission" (→waiting) → *you approve* → tool runs →
+`PostToolUse` (→working). **No hook fires between approval and tool completion**
+(`PreToolUse` already ran *before* the prompt), so from the moment you approve
+until the tool finishes, the file still says `waiting` and the tab shows ⏸ **while
+it is actually running**. Window of wrongness = the tool's post-approval
+duration; it self-heals at `PostToolUse`. Observed as "tab took 3–5s to turn
+green after I approved" (the tool ran 3–5s under a stale ⏸).
+
+**Decision: accept it.** It's bounded and self-healing, prompts are relatively
+rare (common commands are allow-listed), and the ⏸-at-a-permission-prompt cue is
+genuinely useful (it pulls you back to a blocked tab) — so we keep it rather than
+force permission prompts green. The redraw timer does **not** fix this (the file
+genuinely says `waiting`); if anything it makes the transient show more
+faithfully. A real fix would need a Claude Code hook that fires on permission
+grant / tool-execution start, which doesn't exist today.
 
 ## Diagnostic instrumentation (temporary)
 
@@ -175,11 +240,17 @@ during long tools and during idle alike. Read the state writes, not the beats.
 
 ## Fix direction
 
-- **Stuck `waiting` (#2): DONE** — `Notification` no longer writes `waiting` for
-  its idle nudge (see "Root cause of stuck `waiting`" above).
-- **Stuck `working` (#1): still open.** On ESC interrupt no hook fires, so the
-  `working` file is never corrected; it self-heals only when the next turn ends
-  (`Stop`). A freshness/TTL reconciler is **not** viable — there's no continuous
-  working heartbeat (see the answered open question), so a TTL can't tell a
-  long-running tool from an aborted turn. Needs a real interrupt-time signal
+- **Renderer lag (the dominant cause): DONE (2026-07-21)** — `tab_bar.py` now
+  polls on a 2s timer and repaints only on a real state change, so glyphs track
+  their files on untouched tabs. **Needs a kitty restart to activate.**
+- **Stuck `waiting` — idle nudge: DONE (2026-07-17)** — `Notification` no longer
+  writes `waiting` for its idle nudge (see "Root cause of stuck `waiting`").
+- **Stuck `waiting` — permission-gated tool: WON'T FIX (accepted)** — no hook
+  fires between approval and tool completion; bounded and self-healing (see
+  "Permission-gated tool shows ⏸").
+- **Stuck `working` — true ESC interrupt: residual, open.** With the renderer
+  fixed, this shrinks to the genuine case where ESC aborts a turn and no `Stop`
+  fires, so `working` is never corrected until the next turn ends. A freshness/TTL
+  reconciler is still **not** viable — no continuous working heartbeat, so a TTL
+  can't tell a long tool from an aborted turn. Needs a real interrupt-time signal
   (does Claude Code expose one?) before it's worth touching.

--- a/dot_config/kitty/tab_bar.py
+++ b/dot_config/kitty/tab_bar.py
@@ -19,6 +19,7 @@
 import os
 import time
 
+from kitty.fast_data_types import add_timer
 from kitty.tab_bar import as_rgb, draw_tab_with_powerline, get_boss
 
 STATE_DIR = "/tmp/claude-kitty-state"
@@ -83,6 +84,73 @@ def _states_for_tab(tab_id):
         except OSError:
             pass
     return found
+
+
+# --- periodic redraw so glyphs track their state files -------------------
+# kitty only repaints the tab bar on its own triggers (focus change, keypress,
+# focused-window output, bell, title change). A state file changing on disk is
+# NOT one of them, so a tab that transitions working<->waiting while you are not
+# interacting with it (a background tab, or the tab that just finished a turn)
+# keeps showing its previous glyph until some unrelated event happens to repaint
+# -- the "wrong icon that heals when you touch it" bug. We fix it by polling the
+# state dir on a timer and marking the tab bar dirty ONLY when a state file
+# actually changed. When nothing changed (idle sessions, or no Claude open at
+# all) a tick is just one listdir + a few stats and forces no repaint, so the
+# cost is negligible; kitty also skips the repaint entirely for occluded windows.
+_REDRAW_INTERVAL = 2.0  # seconds; how quickly a glyph catches up to its file
+_last_sig = None
+
+
+def _state_signature():
+    # Cheap fingerprint of the state dir: (window-id, mtime_ns) per state file.
+    # Only numeric names are state files -- skip debug.log/statusline.log/.debug
+    # so diagnostic logging churn never triggers a redraw.
+    try:
+        names = os.listdir(STATE_DIR)
+    except OSError:
+        return ()
+    sig = []
+    for name in names:
+        if not name.isdigit():
+            continue
+        try:
+            sig.append((name, os.stat(os.path.join(STATE_DIR, name)).st_mtime_ns))
+        except OSError:
+            pass
+    sig.sort()
+    return tuple(sig)
+
+
+def _poll_redraw(timer_id):
+    global _last_sig
+    sig = _state_signature()
+    if sig == _last_sig:
+        return  # nothing changed -> no repaint (the common, near-free case)
+    _last_sig = sig
+    boss = get_boss()
+    if boss is None:
+        return
+    try:
+        managers = list(boss.os_window_map.values())
+    except Exception:
+        tm = getattr(boss, "active_tab_manager", None)
+        managers = [tm] if tm is not None else []
+    for tm in managers:
+        try:
+            tm.mark_tab_bar_dirty()
+        except Exception:
+            pass
+
+
+try:
+    # seed the signature with the state at import so the first tick only fires on
+    # a real change (the import-time render already reflects the current files).
+    _last_sig = _state_signature()
+    add_timer(_poll_redraw, _REDRAW_INTERVAL, True)
+except Exception:
+    # if the timer can't be registered, fall back to kitty's native repaint
+    # triggers -- degraded (laggy glyphs) but never broken.
+    pass
 
 
 def draw_tab(


### PR DESCRIPTION
## Problem

The play/pause tab icons for Claude Code sessions were intermittently wrong and "healed when you touched the tab" — worse with 3–4 tabs open. Turning on the diagnostic logging showed the **state files were always correct** (every hook writes sub-second); the **glyph** was stale. It was not caused by the ESC key.

## Root cause (renderer lag)

kitty repaints the tab bar only on its own triggers (focus change, keypress, focused-window output, bell, title change). A Claude state file changing on disk is **not** one of them. So when a session transitions `working`↔`waiting` on a tab you're not interacting with — a background tab, or the tab that just finished its turn and went quiet — the glyph keeps showing the previous state until some unrelated event repaints the bar. This also explains stale ▸ on a *normal* (non-ESC) `Stop`: the `waiting` file is written instantly, but nothing tells kitty to repaint.

## Fix

`tab_bar.py` registers a 2s `add_timer` that fingerprints the state dir (numeric files only, so debug-logging churn is ignored) and calls `mark_tab_bar_dirty()` **only when a state file's mtime actually changed**. Glyphs now track their files within ~2s on untouched tabs.

- **Negligible cost:** idle ticks do just a `listdir` + a few `stat`s and force **no** repaint; kitty also skips repaints for occluded windows. The timer lives in kitty, not Claude.
- **Renderer-only change** — state stays 100% hook-driven; the earlier "no heartbeat → no TTL reconciler" reasoning is untouched.
- Change-detection logic verified in isolation against the live state dir (ignores logs; catches writes / new sessions / idle removal).

## Activation

⚠️ **Requires a full kitty restart** — kitty imports `tab_bar.py` once at startup and `load_config` does not re-import it. Verify after restart: watch a background/idle tab change state on its own within ~2s without touching it.

## Also documented (not fixed — accepted limitation)

Permission-gated tools show `⏸` while running: no hook fires between "you approve" and "tool finishes," so the file stays `waiting` until `PostToolUse`. Bounded and self-healing; kept because `⏸` at a permission prompt is a useful "come back here" cue. See docs.

## Revert

Renderer-only, behind a single timer registration — revert this PR and restart kitty to fully undo.