### PR TITLE
Split turn-ended tab icon (⏹ stop) from waiting-for-input (⏸)

### DIFF
--- a/docs/kitty-claude-tab-icons.md
+++ b/docs/kitty-claude-tab-icons.md
@@ -6,7 +6,8 @@ running in it:
 | Glyph | Colour | Meaning | Written by |
 |---|---|---|---|
 | `▸` | green (`0x00CC66`) | working | `UserPromptSubmit`, `PreToolUse`, `PostToolUse` |
-| `⏸` | amber (`0xFFB000`) | waiting / needs you | `Stop`, `Notification` (permission prompts only — see below) |
+| `⏸` | amber (`0xFFB000`) | waiting for your input | `Notification` (permission prompts only — see below) |
+| `⏹` | blue (`0x3B82F6`) | turn ended, your move | `Stop` |
 | *(none)* | — | idle | `SessionStart`, `SessionEnd` (file removed) |
 
 This doc is the pickup point for the **known "wrong icon" bug** (see below) and
@@ -21,8 +22,9 @@ read the live files — they carry their own header comments:
 
 State is a **single last-writer-wins file per kitty window** at
 `/tmp/claude-kitty-state/<KITTY_WINDOW_ID>`, containing the literal word
-`working` or `waiting` (absent = idle). Claude Code hooks run `tab-state.sh
-<state>`; the script writes the file. `tab_bar.py` is imported by kitty once at
+`working`, `waiting`, or `stop` (absent = idle). Claude Code hooks run
+`tab-state.sh <state>`; the script writes the file. `tab_bar.py` is imported by
+kitty once at
 startup and, on every tab-bar redraw, reads the state file(s) for the windows in
 each tab and prepends the glyph before handing off to kitty's powerline renderer.
 
@@ -31,8 +33,9 @@ Design notes worth knowing:
 - **Why a file, not an escape sequence:** Claude Code runs hooks without a
   controlling tty, so writing to `/dev/tty` fails. A file needs no kitty remote
   control (which is disabled by default — see commit `9fb38ac`).
-- **Precedence:** `waiting` outranks `working` when a tab has multiple windows
-  (a split that needs you wins). See `STATES` in `tab_bar.py`.
+- **Precedence:** for a tab with multiple windows (a split), the shown glyph is
+  `waiting` > `working` > `stop` — a pane that needs you wins, else anything
+  running, else turn-ended. See `STATES` in `tab_bar.py`.
 - **Stale-session sweep:** kitty reuses window ids (1, 2, 3…) across restarts,
   but state files survive until reboot, so `tab_bar.py` records its import time
   (`_SESSION_START`) and `_sweep_stale()` drops any state file older than that on
@@ -127,7 +130,8 @@ Confirmed in the log: a `Notification` 7s into a 3-min `Bash` held ⏸ from
 **Fix:** `Notification` now calls `tab-state.sh notify`, which inspects the hook
 `message` and writes `waiting` only for permission prompts; the idle nudge is
 dropped (unknown messages still default to `waiting` so no genuine "needs you" is
-lost). Normal turn-end ⏸ is unaffected — it comes from the `Stop` hook. The
+lost). Normal turn-end is unaffected — it comes from the `Stop` hook (now the
+`stop`/⏹ state; the `⏸`/`waiting` glyph in this section predates that split). The
 message-matching is deliberately loose (`*permission*` / `*input*`); the debug
 log now records `msg=` so the patterns can be verified/tuned against real
 notifications.

--- a/dot_claude/executable_tab-state.sh
+++ b/dot_claude/executable_tab-state.sh
@@ -9,9 +9,11 @@
 # without a controlling tty (writing to /dev/tty fails), and this needs no
 # kitty remote control. Always exits 0 so a hook can never surface an error.
 #
-# Usage: tab-state.sh working|waiting|idle|notify
+# Usage: tab-state.sh working|waiting|stop|idle|notify
 #
-#   working|waiting|idle -> write the state verbatim (waiting) / remove file (idle)
+#   working|waiting|stop -> write the state verbatim (glyph via ~/.config/kitty/tab_bar.py:
+#                           working=▸ / waiting=⏸ needs your input / stop=⏹ turn ended)
+#   idle                 -> remove the file (no glyph)
 #   notify               -> a Claude "Notification" hook fired; resolve it (see below)
 #
 # Why `notify` is special: Claude fires the Notification hook for TWO unrelated
@@ -80,7 +82,7 @@ fi
 
 case "$state" in
     idle) rm -f "$file" 2>/dev/null ;;
-    working | waiting) printf '%s' "$state" >"$file" 2>/dev/null ;;
+    working | waiting | stop) printf '%s' "$state" >"$file" 2>/dev/null ;;
     # ignore -> leave the current state file untouched
 esac
 

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$HOME/.claude/tab-state.sh\" waiting"
+            "command": "\"$HOME/.claude/tab-state.sh\" stop"
           }
         ]
       }

--- a/dot_config/kitty/tab_bar.py
+++ b/dot_config/kitty/tab_bar.py
@@ -10,9 +10,10 @@
 # State is written per-window by Claude Code hooks (see ~/.claude/tab-state.sh,
 # wired up in ~/.claude/settings.json) into /tmp/claude-kitty-state/<window-id>:
 #
-#   UserPromptSubmit -> "working"  -> ▸ green
-#   Stop/Notification -> "waiting" -> ⏸ amber (takes precedence: it needs you)
-#   SessionStart/End -> file removed -> idle -> no glyph
+#   UserPromptSubmit/PreToolUse/PostToolUse -> "working" -> ▸ green
+#   Notification (permission prompt)        -> "waiting" -> ⏸ amber (needs your input)
+#   Stop                                    -> "stop"    -> ⏹ blue  (turn ended, your move)
+#   SessionStart/End -> file removed        -> idle      -> no glyph
 #
 # Tweak the glyphs/colours/precedence in STATES below.
 
@@ -47,11 +48,13 @@ def _sweep_stale():
         except OSError:
             pass
 
-# checked in order -> first match wins (waiting outranks working)
+# checked in order -> first match wins. For a split tab with multiple panes:
+# waiting (needs you) > working (running) > stop (turn ended, your move).
 # (state name, glyph, 0xRRGGBB)
 STATES = (
-    ("waiting", "⏸", 0xFFB000),  # amber
-    ("working", "▸", 0x00CC66),  # green
+    ("waiting", "⏸", 0xFFB000),  # amber — needs your input (permission prompt)
+    ("working", "▸", 0x00CC66),  # green — running
+    ("stop",    "⏹", 0x3B82F6),  # blue  — turn ended, your move
 )
 
 


### PR DESCRIPTION
## What

Currently both the `Stop` hook and the permission `Notification` write `waiting`/`⏸`, so **"Claude finished, your move"** looks identical to **"Claude is blocked on a permission prompt."** This splits them into distinct glyphs:

| Glyph | State | Meaning | Hook |
|---|---|---|---|
| `▸` green | `working` | running | `UserPromptSubmit` / `PreToolUse` / `PostToolUse` |
| `⏸` amber | `waiting` | waiting for your input | `Notification` (permission prompt) |
| `⏹` blue | `stop` | turn ended, your move | `Stop` |

## Naming

Token is `stop` (not `done`) so it mirrors the `Stop` hook — one word through the whole chain: **Stop hook → `stop` state → ⏹ stop-button glyph**. Its *meaning* is documented as "turn ended, your move" in the code comment and docs so `⏹` isn't misread as "aborted/interrupted."

## Changes

- **`settings.json`** — `Stop` hook now calls `tab-state.sh stop` (was `waiting`).
- **`tab-state.sh`** — accept `stop` in the write `case`. `notify` is unchanged: permission prompts still resolve to `waiting`, idle nudge to `ignore`.
- **`tab_bar.py`** — add `("stop", "⏹", 0x3B82F6)` to `STATES`. Split-tab precedence: `waiting` > `working` > `stop`.
- **docs** — glyph table, state-word list, precedence note.

Verified: syntax/JSON valid, source==deployed copy, and the `Stop` path now writes `stop` to the state file.

## Activation

`tab-state.sh` / `settings.json` take effect for **new Claude sessions**; `tab_bar.py` needs a **kitty restart**. Renderer/token-only change — easy to revert by reverting this PR.